### PR TITLE
Fix OBS connection call for websocket v5

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ let lastPlayedTime = 0;
 // Connect to OBS
 async function connectToOBS() {
   try {
-    await obs.connect(`ws://${config.obs.host}:${config.obs.port}`, config.obs.password);
+    await obs.connect(`ws://${config.obs.host}:${config.obs.port}`, { password: config.obs.password });
     console.log('Connected to OBS');
     return true;
   } catch (error) {
@@ -59,35 +59,37 @@ async function connectToOBS() {
 // Play audio in OBS
 async function playAudioInOBS(audioPath) {
   try {
-    // Create a media source if it doesn't exist
-    const sources = await obs.call('GetSourcesList');
-    const mediaSourceExists = sources.sources.some(source => source.name === 'ChatVoiceAudio');
+    // Create a media source if it doesn't exist (OBS WebSocket 5.x uses inputs)
+    const inputs = await obs.call('GetInputList');
+    const mediaSourceExists = inputs.inputs.some(input => input.inputName === 'ChatVoiceAudio');
     
     if (!mediaSourceExists) {
-      await obs.call('CreateSource', {
-        sourceName: 'ChatVoiceAudio',
-        sourceKind: 'ffmpeg_source',
+      await obs.call('CreateInput', {
         sceneName: config.obs.scene,
-        sourceSettings: {
+        inputName: 'ChatVoiceAudio',
+        inputKind: 'ffmpeg_source',
+        inputSettings: {
           local_file: audioPath,
           looping: false
-        }
+        },
+        sceneItemEnabled: true
       });
     } else {
       // Update the media source with the new audio file
-      await obs.call('SetSourceSettings', {
-        sourceName: 'ChatVoiceAudio',
-        sourceSettings: {
+      await obs.call('SetInputSettings', {
+        inputName: 'ChatVoiceAudio',
+        inputSettings: {
           local_file: audioPath,
           looping: false
-        }
+        },
+        overlay: false
       });
     }
     
     // Play the media
-    await obs.call('PlayPauseMedia', {
-      sourceName: 'ChatVoiceAudio',
-      playPause: true
+    await obs.call('TriggerMediaInputAction', {
+      inputName: 'ChatVoiceAudio',
+      mediaAction: 'OBS_WEBSOCKET_MEDIA_INPUT_ACTION_RESTART'
     });
     
     console.log('Playing audio in OBS');

--- a/test-obs-connection.js
+++ b/test-obs-connection.js
@@ -20,7 +20,7 @@ async function testOBSConnection() {
   
   try {
     // Connect to OBS
-    await obs.connect(`ws://${config.obs.host}:${config.obs.port}`, config.obs.password);
+    await obs.connect(`ws://${config.obs.host}:${config.obs.port}`, { password: config.obs.password });
     
     console.log('\nConnection successful!');
     
@@ -40,11 +40,11 @@ async function testOBSConnection() {
       console.log(`- ${scene.sceneName}`);
     });
     
-    // List available sources
-    const sources = await obs.call('GetSourcesList');
-    console.log('\nAvailable Sources:');
-    sources.sources.forEach(source => {
-      console.log(`- ${source.name} (${source.typeId})`);
+    // List available inputs (sources)
+    const inputs = await obs.call('GetInputList');
+    console.log('\nAvailable Inputs:');
+    inputs.inputs.forEach(input => {
+      console.log(`- ${input.inputName} (${input.inputKind})`);
     });
     
     console.log('\nAll tests passed! OBS connection is working correctly.');


### PR DESCRIPTION
## Summary
- use password option object when connecting to OBS WebSocket v5

## Testing
- `npm test` *(fails: OpenAI/ElevenLabs errors)*
- `npm run test:obs` *(fails: cannot connect to OBS)*
- `npm run test:twitch` *(fails: unable to connect to Twitch)*
- `npm run test:voice` *(fails: ElevenLabs connection error)*
- `npm run test:ai` *(fails: OpenAI connection error)*

------
https://chatgpt.com/codex/tasks/task_e_6841ca073e78832d93c9f352f94f7799